### PR TITLE
Fix form_urlencoded::serialize() removed in rust-url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ path = "src/lib.rs"
 [dependencies]
 hyper = "0.5"
 rust-crypto = "0.2"
-url = "*"
+url = "^1.0"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,7 @@ pub trait Utils {}
 
 impl Utils {
   pub fn to_query_string(params: &Params) -> String {
-    return form_urlencoded::serialize(params.into_iter())
+    return form_urlencoded::Serializer::new(String::new()).extend_pairs(params.into_iter()).finish();
   }
 
   pub fn checksum(query_string: &String) -> String {


### PR DESCRIPTION
The rust-url library is now version 1.0 which has brought a few changes. Most notably `form_urlencoded::serialize()` has been removed. This causes the following error when compiling:

``` bash
Error[E0425]: unresolved name `form_urlencoded::serialize`
  --> src/utils.rs:12:12
```

This pull request fixes this error by following the guide at https://github.com/servo/rust-url/blob/2b9bd900f0c1d4d09a9f8e942419a19830d2a851/UPGRADING.md. It also sets 1.x as the required version of rust-url to avoid problems like this in the future.
